### PR TITLE
chore: 更新构建配置以支持Linux

### DIFF
--- a/src-tauri/EcoPaste.desktop
+++ b/src-tauri/EcoPaste.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name={{{name}}}
+Exec={{{exec}}}
+Icon={{{icon}}}
+Categories={{{categories}}}
+Comment={{{comment}}}
+Terminal=false

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -78,31 +78,7 @@
 				"icons/128x128@2x.png",
 				"icons/icon.icns",
 				"icons/icon.ico"
-			],
-			"externalBin": ["bin/ocr"],
-			"windows": {
-				"digestAlgorithm": "sha256",
-				"wix": {
-					"language": "zh-CN"
-				},
-				"nsis": {
-					"languages": ["SimpChinese"]
-				}
-			},
-			"dmg": {
-				"appPosition": {
-					"x": 180,
-					"y": 170
-				},
-				"applicationFolderPosition": {
-					"x": 480,
-					"y": 170
-				},
-				"windowSize": {
-					"width": 660,
-					"height": 400
-				}
-			}
+			]
 		},
 		"systemTray": {
 			"iconPath": "assets/tray.png",

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,16 @@
+{
+	"tauri": {
+		"bundle": {
+			"identifier": "com.ayangweb.EcoPaste",
+			"targets": ["deb"],
+			"deb": {
+				"depends": ["gstreamer1.0-plugins-good"],
+				"desktopTemplate": "./EcoPaste.desktop"
+			},
+			"rpm": {
+				"depends": ["gstreamer1-plugins-good"],
+				"desktopTemplate": "./EcoPaste.desktop"
+			}
+		}
+	}
+}

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,22 @@
+{
+	"tauri": {
+		"bundle": {
+			"identifier": "com.ayangweb.EcoPaste",
+			"externalBin": ["bin/ocr"],
+			"dmg": {
+				"appPosition": {
+					"x": 180,
+					"y": 170
+				},
+				"applicationFolderPosition": {
+					"x": 480,
+					"y": 170
+				},
+				"windowSize": {
+					"width": 660,
+					"height": 400
+				}
+			}
+		}
+	}
+}

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,17 @@
+{
+	"tauri": {
+		"bundle": {
+			"identifier": "com.ayangweb.EcoPaste",
+			"externalBin": ["bin/ocr"],
+			"windows": {
+				"digestAlgorithm": "sha256",
+				"wix": {
+					"language": "zh-CN"
+				},
+				"nsis": {
+					"languages": ["SimpChinese"]
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
#75 macOS和Windows的构建也采用Platform-Specific Configuration进行拆分了，应该是等价的，但是可能需要测试。