### PR TITLE
refactor: 暂时将偏好设置作为主窗口

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,7 +8,7 @@ mod plugins;
 use core::tray;
 use plugins::{
     auto_launch, backup, clipboard, fs_extra, locale, mouse, ocr, paste,
-    window::{self, show_window, MAIN_WINDOW_LABEL},
+    window::{self, show_window, PREFERENCE_WINDOW_LABEL},
 };
 use tauri::{
     async_runtime, generate_context, generate_handler, Builder, Manager, SystemTray, WindowEvent,
@@ -23,11 +23,13 @@ fn main() {
 
     Builder::default()
         .setup(|app| {
-            let _window = app.get_window(MAIN_WINDOW_LABEL).unwrap();
-
             // 在开发环境中启动时打开控制台：https://tauri.app/v1/guides/debugging/application/#opening-devtools-programmatically
             #[cfg(any(debug_assertions, feature = "devtools"))]
-            _window.open_devtools();
+            {
+                let window = app.get_window(PREFERENCE_WINDOW_LABEL).unwrap();
+
+                window.open_devtools();
+            }
 
             #[cfg(target_os = "macos")]
             {
@@ -44,7 +46,7 @@ fn main() {
         .plugin(ThemePlugin::init(ctx.config_mut()))
         // 确保在 windows 和 linux 上只有一个 app 实例在运行：https://github.com/tauri-apps/plugins-workspace/tree/v1/plugins/single-instance
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
-            let window = app.get_window(MAIN_WINDOW_LABEL).unwrap();
+            let window = app.get_window(PREFERENCE_WINDOW_LABEL).unwrap();
 
             async_runtime::block_on(async move {
                 show_window(window).await;

--- a/src-tauri/src/plugins/window.rs
+++ b/src-tauri/src/plugins/window.rs
@@ -6,7 +6,7 @@ use tauri::{
 };
 
 // 主窗口的label
-pub static MAIN_WINDOW_LABEL: &str = "main";
+// pub static MAIN_WINDOW_LABEL: &str = "main";
 // 偏好设置窗口的label
 pub static PREFERENCE_WINDOW_LABEL: &str = "preference";
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -56,18 +56,15 @@
 		},
 		"windows": [
 			{
-				"label": "main",
-				"title": "EcoPaste",
-				"width": 360,
-				"height": 600,
+				"label": "preference",
+				"url": "/preference",
+				"center": true,
 				"resizable": false,
 				"maximizable": false,
-				"decorations": false,
+				"hiddenTitle": true,
+				"skipTaskbar": true,
 				"visible": false,
-				"transparent": true,
-				"alwaysOnTop": true,
-				"acceptFirstMouse": true,
-				"skipTaskbar": true
+				"titleBarStyle": "Overlay"
 			}
 		],
 		"security": {

--- a/src/layouts/Preference/index.tsx
+++ b/src/layouts/Preference/index.tsx
@@ -16,7 +16,15 @@ const Preference = () => {
 	const { theme, isDark, toggleTheme } = useTheme();
 	const { t } = useTranslation();
 
-	useMount(() => {
+	useMount(async () => {
+		const autoLaunched = await isAutoLaunch();
+
+		if (!autoLaunched) {
+			showWindow();
+		}
+
+		createWindow("/");
+
 		if (!isWin()) {
 			toggleTheme(theme);
 		}

--- a/src/pages/Clipboard/History/index.tsx
+++ b/src/pages/Clipboard/History/index.tsx
@@ -46,10 +46,6 @@ const ClipboardHistory = () => {
 	const state = useReactive<State>(INITIAL_STATE);
 
 	useMount(async () => {
-		const autoLaunched = await isAutoLaunch();
-
-		createWindow("/preference", { visible: !autoLaunched });
-
 		setWindowShadow();
 
 		startListen();

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -46,15 +46,6 @@ export const preferenceRoute: Route = {
 			},
 		},
 	],
-	meta: {
-		windowOptions: {
-			center: true,
-			resizable: false,
-			maximizable: false,
-			hiddenTitle: true,
-			titleBarStyle: "overlay",
-		},
-	},
 };
 
 export const routes: Route[] = [
@@ -62,6 +53,19 @@ export const routes: Route[] = [
 	{
 		path: "/",
 		Component: ClipboardHistory,
+		meta: {
+			windowOptions: {
+				width: 360,
+				height: 600,
+				resizable: false,
+				maximizable: false,
+				decorations: false,
+				visible: false,
+				transparent: true,
+				alwaysOnTop: true,
+				acceptFirstMouse: true,
+			},
+		},
 	},
 ];
 


### PR DESCRIPTION
暂时将偏好设置作为主窗口，后续如果将剪切板作为主窗口，需要解决剪切板无法在 MacOS 的全屏窗口上显示的问题！