### PR TITLE
fix: 修复 windows 任务管理器 app 名称显示错误的问题

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -84,6 +84,7 @@
 		"bundle": {
 			"active": true,
 			"targets": "all",
+			"shortDescription": "EcoPaste",
 			"identifier": "com.ayangweb.EcoPaste",
 			"icon": [
 				"icons/32x32.png",


### PR DESCRIPTION
closed #292

只有打包才能正确显示，dev 模式依旧错误！