### PR TITLE
fix: 修复了富文本内容字符个数不正确的问题

### DIFF
--- a/src/plugins/clipboard.ts
+++ b/src/plugins/clipboard.ts
@@ -141,12 +141,12 @@ export const readHTML = async (): Promise<ClipboardPayload> => {
 export const readRichText = async (): Promise<ClipboardPayload> => {
 	const richText = await invoke<string>(CLIPBOARD_PLUGIN.READ_RICH_TEXT);
 
-	const { value } = await readText();
+	const { value, size } = await readText();
 
 	return {
 		value: richText,
 		search: value,
-		size: richText.length,
+		size,
 	};
 };
 


### PR DESCRIPTION
closed #454 

<img width="408" alt="image" src="https://github.com/user-attachments/assets/d9593547-d2d5-4683-a184-182df41e9d6d">
